### PR TITLE
Feature/get env from instance tags

### DIFF
--- a/dj_secure_settings/loader.py
+++ b/dj_secure_settings/loader.py
@@ -4,6 +4,7 @@ import os
 import sys
 
 import boto3
+from botocore.exceptions import NoRegionError
 import requests
 import yaml
 
@@ -94,7 +95,7 @@ def _load_params_from_yaml(config, yaml_params, env, namespace):
         pass
 
 
-def _load_params_from_ssm(config, path_prefix, region_name):
+def _load_params_from_ssm(config, path_prefix, region_name=None):
     # Load parameters from SSM Parameter Store starting with path.
     # Populate the config dict using keys from the path after the path_prefix
     if region_name:

--- a/dj_secure_settings/loader.py
+++ b/dj_secure_settings/loader.py
@@ -32,7 +32,6 @@ def load_secure_settings(project_name=None, environment=None):
             except:
                 # raise an exception
                 raise EnvironmentError('The ENV environment variable must be set or an ec2 tag "env" must be set.')
-    else:
 
     caller_filename = inspect.stack()[1][1]
     # this is the path which contains the caller's module:

--- a/dj_secure_settings/loader.py
+++ b/dj_secure_settings/loader.py
@@ -31,6 +31,7 @@ def load_secure_settings(project_name=None, environment=None):
             try:
                 # get the environment from an ec2 instance tag
                 env = _get_env_from_ec2_tag()
+                logger.info('Using environment {} from ec2 metadata tags'.format(env))
             except:
                 # raise an exception
                 raise EnvironmentError('The ENV environment variable must be set or an ec2 tag "env" must be set.')

--- a/dj_secure_settings/loader.py
+++ b/dj_secure_settings/loader.py
@@ -58,7 +58,7 @@ def load_secure_settings(project_name=None, environment=None):
     # next try to overlay those parameters with values from a local file
     caller = inspect.stack()[1]
     try:
-        yaml_params = yaml.load(open(yaml_file))
+        yaml_params = yaml.load(open(yaml_file), Loader=yaml.Loader)
         _load_params_from_yaml(config, yaml_params, env, 'defaults')
         _load_params_from_yaml(config, yaml_params, env, project_name)
     except:

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ os.chdir(os.path.normpath(os.path.join(os.path.abspath(__file__), os.pardir)))
 
 setup(
     name='django-ssm-parameter-store',
-    version='0.1',
+    version='0.2',
     packages=find_packages(),
     include_package_data=True,
     license='BSD License',  # example license

--- a/setup.py
+++ b/setup.py
@@ -34,5 +34,6 @@ setup(
     install_requires=[
         "boto3>=1.9.91",
         "PyYAML>=3.13",
+        "requests>=2",
     ],
 )


### PR DESCRIPTION
When we're running in ECS, it's easy to provide the environment value in an environment variable. When we're running on EC2, it's handy to be able to get the environment value from the tag that's on the instance. We can also get the region from the instance metadata. 
