### PR TITLE
Explicitly set the botocore retry mode to `standard` 

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ os.chdir(os.path.normpath(os.path.join(os.path.abspath(__file__), os.pardir)))
 
 setup(
     name='django-ssm-parameter-store',
-    version='0.5',
+    version='0.6',
     packages=find_packages(),
     include_package_data=True,
     license='BSD License',  # example license


### PR DESCRIPTION
This PR configures the SSM client to use botocore's `standard` retry mode (instead of `legacy`). 

More info on configuring retry modes here: https://boto3.amazonaws.com/v1/documentation/api/latest/guide/retries.html

